### PR TITLE
Column statistics fix

### DIFF
--- a/commands/dbsync.js
+++ b/commands/dbsync.js
@@ -174,7 +174,7 @@ function * run (context, heroku) {
     let additional_mysqldump_parameters = "";
 
     if(!context.flags['lock-database']) {
-        additional_mysqldump_parameters = "--single-transaction --quick";
+        additional_mysqldump_parameters = "--single-transaction --quick --column-statistics=0";
     }
 
     if(run_scripts)

--- a/commands/dump.js
+++ b/commands/dump.js
@@ -99,7 +99,7 @@ function * run (context, heroku) {
     let additional_mysqldump_parameters = "";
 
     if(!context.flags['lock-database']) {
-        additional_mysqldump_parameters = "--single-transaction --quick";
+        additional_mysqldump_parameters = "--single-transaction --quick --column-statistics=0";
     }
 
     let mysql_auth_params = library.createMysqlAuthParameters(database.host, database.user, database.password, database.database);

--- a/library/library.js
+++ b/library/library.js
@@ -98,7 +98,7 @@ var lib = {
         return tmp_mysql_db;
     },
 
-    createMysqlAuthParameters : function (host, user, pass, database) {
+    createMysqlAuthParameters : function (host, user, pass, database) {
         let output = `-h${host} -u${user}`;
 
         if(pass) {


### PR DESCRIPTION
Mysql enabled column-statistics flag by default, which causes this script to silently fail in JawsDB, unless the user has disabled this flag in their local mysql config.

Specifically disabling this flag in mysqldump parameters avoids unnecessary headaches for users.